### PR TITLE
Generate token by GitHub Apps

### DIFF
--- a/.github/workflows/versions.yaml
+++ b/.github/workflows/versions.yaml
@@ -18,9 +18,14 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.1
+      - uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.TOKEN_GENERATOR_APP_ID }}
+          private_key: ${{ secrets.TOKEN_GENERATOR_PRIVATE_KEY }}
+        id: generate_token
       - name: Update versions.json
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
         run: |
           ruby versions.rb > versions.json
 


### PR DESCRIPTION
I've created my personal GitHub App which has write privileges on pull requests and contents.
ref: https://zenn.dev/suzutan/articles/how-to-use-github-apps-token-in-github-actions (in Japanese)

`TOKEN_GENERATOR_APP` is its App ID.
`TOKEN_GENERATOR_PRIVATE_KEY` is its private key.
