### PR TITLE
Skip 6.0 temporarily

### DIFF
--- a/versions.rb
+++ b/versions.rb
@@ -7,7 +7,7 @@ require "uri"
 
 JSON_URL = "https://downloads.mongodb.org/current.json"
 MIN_MAJOR_VERSION = 4
-SKIPPED_MINOR_VERSIONS = ["5.3"]
+SKIPPED_MINOR_VERSIONS = ["5.3", "6.0"]
 
 minor_versions = Set.new
 


### PR DESCRIPTION
ref: https://github.com/a2ikm/docker-sharded-mongo/pull/22