### PR TITLE
Tweak skipped versions

### DIFF
--- a/versions.rb
+++ b/versions.rb
@@ -7,7 +7,7 @@ require "uri"
 
 JSON_URL = "https://downloads.mongodb.org/current.json"
 MIN_MAJOR_VERSION = 4
-SKIPPED_MINOR_VERSIONS = ["5.3", "6.0"]
+SKIPPED_MINOR_VERSIONS = ["5.3", "6.1"]
 
 minor_versions = Set.new
 


### PR DESCRIPTION
Skip 6.1, accept 6.0.

mongo:6.0 has been released.
https://hub.docker.com/layers/library/mongo/6.0/images/sha256-e0b1614551474ee2f3c3ef7c9706b5e19f2107aa36b73c910522af9fa8eb756e?context=explore