### PR TITLE
Use mongosh instead of mongo

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,6 +1,24 @@
 ARG MONGO_VERSION=latest
 FROM mongo:${MONGO_VERSION}
 
+RUN set -eux; \
+      dpkgArch="$(dpkg --print-architecture)"; \
+      case "${dpkgArch##*-}" in \
+            amd64) mongoshArch='linux-x64' ;; \
+            arm64) mongoshArch='linux-arm64' ;; \
+            *) echo >&2; echo >&2 "error: current architecture ($dpkgArch) is not supported"; echo >&2; exit 1 ;; \
+      esac; \
+      \
+      apt-get update && \
+      apt-get install -y wget && \
+      wget https://downloads.mongodb.com/compass/mongosh-1.6.0-${mongoshArch}.tgz && \
+      tar zxf mongosh-1.6.0-${mongoshArch}.tgz && \
+      chmod +x mongosh-1.6.0-${mongoshArch}/bin/mongosh && \
+      mv mongosh-1.6.0-${mongoshArch}/bin/mongosh /usr/local/bin && \
+      mv mongosh-1.6.0-${mongoshArch}/bin/mongosh_crypt_v1.so /usr/local/lib && \
+      rm -rf mongosh-1.6.0-${mongoshArch}.tgz mongosh-1.6.0-${mongoshArch} && \
+      rm -rf /var/lib/apt/lists/*
+
 RUN mkdir -p \
       /var/lib/sharded-mongo/mongod-config \
       /var/lib/sharded-mongo/mongod-shard \

--- a/src/docker-entrypoint.sh
+++ b/src/docker-entrypoint.sh
@@ -16,7 +16,7 @@ mongod \
   --logpath /var/log/mongod-config.log
 
 if [ ! -e /var/lib/sharded-mongo/mongod-config.initialized ]; then
-  mongo --eval 'rs.initiate({_id: "config", configsvr: true, members: [{ _id : 0, host : "localhost:27019" }]})' localhost:27019
+  mongosh --eval 'rs.initiate({_id: "config", configsvr: true, members: [{ _id : 0, host : "localhost:27019" }]})' localhost:27019
   touch /var/lib/sharded-mongo/mongod-config.initialized
 fi
 
@@ -30,7 +30,7 @@ mongod \
   --logpath /var/log/mongod-shard.log
 
 if [ ! -e /var/lib/sharded-mongo/mongod-shard.initialized ]; then
-  mongo --eval 'rs.initiate({_id: "shard", members: [{ _id : 0, host : "localhost:27018" }]})' localhost:27018
+  mongosh --eval 'rs.initiate({_id: "shard", members: [{ _id : 0, host : "localhost:27018" }]})' localhost:27018
   touch /var/lib/sharded-mongo/mongod-shard.initialized
 fi
 
@@ -49,18 +49,18 @@ mongos \
   --logpath /var/log/mongos.log
 
 if [ ! -e /var/lib/sharded-mongo/mongos.initialized ]; then
-  mongo --eval 'sh.addShard("shard/localhost:27018")' localhost:27017
+  mongosh --eval 'sh.addShard("shard/localhost:27018")' localhost:27017
   touch /var/lib/sharded-mongo/mongos.initialized
 
   for f in /docker-entrypoint-initdb.d/*; do
     case "$f" in
       *.sh) echo "$0: running $f"; . "$f" ;;
-      *.js) echo "$0: running $f"; mongo localhost:27017 "$f"; echo ;;
+      *.js) echo "$0: running $f"; mongosh localhost:27017 "$f"; echo ;;
       *)    echo "$0: ignoring $f" ;;
     esac
   done
 fi
 
-mongo --eval 'db.shutdownServer()' localhost:27017/admin
+mongosh --eval 'db.shutdownServer()' localhost:27017/admin || true
 
 exec "$@"

--- a/test/test.sh
+++ b/test/test.sh
@@ -2,10 +2,14 @@
 
 set -Eeu pipefail
 
+echo "[sharded-mongo/test.sh] forking mongos..."
+
 mongos \
   --config /etc/mongos.conf \
   --fork \
   --logpath /var/log/mongos.log
+
+echo "[sharded-mongo/test.sh] inserting documents and counting them..."
 
 js=$(cat << JAVASCRIPT
 db.testcollection.insertMany(
@@ -24,7 +28,7 @@ count=$(mongosh --quiet --eval "$js" localhost:27017/testdb | \
   jq 'map(select(.shardkeyfield == "bar")) | length')
 
 if [[ $count != 1 ]]; then
-  echo "expected 1 but got $count"
+  echo "[sharded-mongo/test.sh] expected 1 but got $count"
   exit 1
 fi
 

--- a/test/test.sh
+++ b/test/test.sh
@@ -20,7 +20,7 @@ JSON.stringify(result)
 JAVASCRIPT
 )
 
-count=$(mongo --quiet --eval "$js" localhost:27017/testdb | \
+count=$(mongosh --quiet --eval "$js" localhost:27017/testdb | \
   jq 'map(select(.shardkeyfield == "bar")) | length')
 
 if [[ $count != 1 ]]; then


### PR DESCRIPTION
MongoDB 6.0 server package removed `mongo` command.
Let's use the new mongo shell command, `mongosh`.
